### PR TITLE
Use spouse income for IDR based payment

### DIFF
--- a/components/income_form.js
+++ b/components/income_form.js
@@ -10,23 +10,74 @@ import {TaxFilingStatus} from '../shared/loan_config'
 import {
   asInt,
   useDeferredOnChange,
-  useOnChange
+  useOnChange,
 } from '@standardlabs/react-hooks'
 
 const IncomeForm = ({onChange, income, ...props}) => {
   const [agi, onChangeAgi] = useDeferredOnChange(income.agi, 150, asInt)
+  const [agiSpouse, onChangeAgiSpouse] = useDeferredOnChange(
+    income.agi_spouse,
+    150,
+    asInt
+  )
   const [dependents, onChangeDependants] = useOnChange(income.dependents, asInt)
   const [state, onChangeState] = useOnChange(income.state)
   const [filing, onChangeFiling] = useOnChange(income.filing)
 
   useEffect(() => {
     if (agi.deferred && dependents && state && filing) {
-      onChange({agi: agi.deferred, dependents, state, filing})
+      onChange({
+        agi: agi.deferred,
+        agi_spouse: agiSpouse.deferred,
+        dependents,
+        state,
+        filing,
+      })
     }
-  }, [onChange, agi.deferred, dependents, state, filing])
+  }, [onChange, agi.deferred, agiSpouse.deferred, dependents, state, filing])
+
+  const isSingle = filing === 'SINGLE'
 
   return (
     <Form {...props}>
+      <Form.Row>
+        <Col>
+          <Form.Group>
+            <Form.Label>Tax filing status</Form.Label>
+            <Select onChange={onChangeFiling} value={filing}>
+              {Object.entries(TaxFilingStatus).map(([key, value]) => (
+                <option key={key} value={key}>
+                  {value}
+                </option>
+              ))}
+            </Select>
+          </Form.Group>
+        </Col>
+        <Col>
+          <Form.Group>
+            <Form.Label>Family size</Form.Label>
+            <Select onChange={onChangeDependants} value={dependents}>
+              {new Array(15).fill(1).map((value, index) => (
+                <option key={index} value={index + 1}>
+                  {index + 1}
+                </option>
+              ))}
+            </Select>
+          </Form.Group>
+        </Col>
+      </Form.Row>
+      <Form.Row>
+        <Col>
+          <Form.Group>
+            <Form.Label>State</Form.Label>
+            <Select onChange={onChangeState} value={state}>
+              <option value={States.LOWER_48}>Lower 48</option>
+              <option value={States.ALASKA}>Alaska</option>
+              <option value={States.HAWAII}>Hawaii</option>
+            </Select>
+          </Form.Group>
+        </Col>
+      </Form.Row>
       <Form.Row>
         <Col xs={12} sm={6}>
           <Form.Group>
@@ -46,42 +97,32 @@ const IncomeForm = ({onChange, income, ...props}) => {
             </InputGroup>
           </Form.Group>
         </Col>
-        <Col>
+        <Col xs={12} sm={6}>
           <Form.Group>
-            <Form.Label>State</Form.Label>
-            <Select onChange={onChangeState} value={state}>
-              <option value={States.LOWER_48}>Lower 48</option>
-              <option value={States.ALASKA}>Alaska</option>
-              <option value={States.HAWAII}>Hawaii</option>
-            </Select>
+            <Form.Label>Spouse income</Form.Label>
+            <InputGroup>
+              <InputGroup.Prepend>
+                <InputGroup.Text>$</InputGroup.Text>
+              </InputGroup.Prepend>
+              <Form.Control
+                value={agiSpouse.value || ''}
+                type="number"
+                min={1000}
+                step={5000}
+                onChange={onChangeAgiSpouse}
+                disabled={isSingle}
+              />
+            </InputGroup>
           </Form.Group>
         </Col>
-      </Form.Row>
-      <Form.Row>
-        <Col>
-          <Form.Group>
-            <Form.Label>Family size</Form.Label>
-            <Select onChange={onChangeDependants} value={dependents}>
-              {new Array(15).fill(1).map((value, index) => (
-                <option key={index} value={index + 1}>
-                  {index + 1}
-                </option>
-              ))}
-            </Select>
-          </Form.Group>
-        </Col>
-        <Col>
-          <Form.Group>
-            <Form.Label>Tax filing status</Form.Label>
-            <Select onChange={onChangeFiling} value={filing}>
-              {Object.entries(TaxFilingStatus).map(([key, value]) => (
-                <option key={key} value={key}>
-                  {value}
-                </option>
-              ))}
-            </Select>
-          </Form.Group>
-        </Col>
+        {!isSingle && (
+          <Col className="mt-n3 mb-2">
+            <Form.Text muted>
+              Certain repayment plans include spousal income when calculating
+              monthly payments, even if filing separately.
+            </Form.Text>
+          </Col>
+        )}
       </Form.Row>
     </Form>
   )
@@ -89,7 +130,7 @@ const IncomeForm = ({onChange, income, ...props}) => {
 
 IncomeForm.propTypes = {
   onChange: PropTypes.func,
-  income: PropTypes.object
+  income: PropTypes.object,
 }
 
 export default IncomeForm

--- a/pages/index.js
+++ b/pages/index.js
@@ -17,7 +17,7 @@ import css from 'styled-jsx/css'
 import {
   consolidateLoans,
   getRepaymentOpions,
-  LoanTypes
+  LoanTypes,
 } from '../shared/loan_config'
 import {useRouteConfig} from '../shared/hooks'
 import {States} from '../shared/calc'
@@ -32,7 +32,7 @@ const Colors = [
   '#a34428',
   '#f19a9b',
   '#7b2995',
-  '#461664'
+  '#461664',
 ]
 
 const Home = () => {
@@ -43,12 +43,13 @@ const Home = () => {
   }
   const [income, setIncome] = useReducer(incomeReducer, {
     agi: 30000,
+    agi_spouse: 25000,
     dependents: 1,
     state: States.LOWER_48,
     filing: 'SINGLE',
-    rates: {income: 0.025, inflation: 0.0236}
+    rates: {income: 0.025, inflation: 0.0236},
   })
-  const onRatesChange = useCallback(rates => setIncome({rates}), [setIncome])
+  const onRatesChange = useCallback((rates) => setIncome({rates}), [setIncome])
 
   const [loans, setLoans] = useState([
     {
@@ -58,17 +59,17 @@ const Home = () => {
       type: 'DIRECT_SUBSIDIZED',
       plan: '',
       payments: 0,
-      expanded: true
-    }
+      expanded: true,
+    },
   ])
   const [loan, setLoan] = useState(consolidateLoans(loans, income))
   useEffect(() => {
     setLoan(consolidateLoans(loans, income))
   }, [income, loans, setLoans])
 
-  const onPaymentSelect = label => {
+  const onPaymentSelect = (label) => {
     if (selectedPayments.includes(label) && selectedPayments.length > 1) {
-      setSelectedPayments(selectedPayments.filter(l => l !== label))
+      setSelectedPayments(selectedPayments.filter((l) => l !== label))
     } else {
       setSelectedPayments([...selectedPayments, label])
     }
@@ -80,14 +81,14 @@ const Home = () => {
 
   const repayments = getRepaymentOpions(loan, income).map((r, i) => ({
     ...r,
-    color: Colors[i]
+    color: Colors[i],
   }))
 
   const [selectedPayments, setSelectedPayments] = useState(
-    repayments.slice(0, 2).map(r => r.label)
+    repayments.slice(0, 2).map((r) => r.label)
   )
 
-  useRouteConfig(config => setIncome(config.income))
+  useRouteConfig((config) => setIncome(config.income))
 
   const {className, styles} = css.resolve`
     .nav-item {
@@ -118,7 +119,8 @@ const Home = () => {
               <p className="mb-5">
                 <a
                   href="http://freestudentloanadvice.org/"
-                  className="text-nowrap">
+                  className="text-nowrap"
+                >
                   The Institute of Student Loan Advisors
                 </a>
               </p>
@@ -168,7 +170,8 @@ const Home = () => {
               {!nav === 'loan' && !income && (
                 <div
                   className="bg-light px-3 py-2 rounded-bottom"
-                  onClick={() => setNav('income')}>
+                  onClick={() => setNav('income')}
+                >
                   <small className="text-muted">
                     Enter your income to see additional options
                   </small>
@@ -215,7 +218,8 @@ const Home = () => {
                 <a
                   href="https://aspe.hhs.gov/poverty-guidelines"
                   rel="noopener noreferrer"
-                  target="_blank">
+                  target="_blank"
+                >
                   Fedral Poverty Guideline
                 </a>{' '}
                 for your family size.

--- a/shared/loan_config.js
+++ b/shared/loan_config.js
@@ -6,7 +6,7 @@ import {
   icrBasedRepayment,
   incomeBasedRepayment,
   partialFinancialHardship,
-  payeBasedRepayment
+  payeBasedRepayment,
 } from './calc'
 
 export const LoanTypes = {
@@ -23,13 +23,13 @@ export const LoanTypes = {
   DIRECT_PLUS_PARENTS: 'Direct PLUS Loan for Parents',
   DIRECT_PLUS_CONSOLIDATED: 'Direct PLUS Consolidation Loan',
   FEDERAL_PERKINS: 'Federal Perkins Loan',
-  PRIVATE: 'Private Loan'
+  PRIVATE: 'Private Loan',
 }
 
 export const TaxFilingStatus = {
   SINGLE: 'Single',
+  MARRIED_SEPARATE: 'Married filing separately',
   MARRIED_JOINT: 'Married filing jointly',
-  MARRIED_SEPARATE: 'Married filing separately'
 }
 
 // Options for existing loan payments.
@@ -41,7 +41,7 @@ export const LoanRepaymentTypes = {
   FIXED_EXTENDED: 'Fixed Extended',
   GRADUATED: 'Graduated',
   GRADUATED_EXTENDED: 'Graduated Extended',
-  INCOME: 'Income Driven Plan'
+  INCOME: 'Income Driven Plan',
 }
 
 const Plans = {
@@ -53,12 +53,12 @@ const Plans = {
   INCOME_BASED_REPAY_NEW: 'INCOME_BASED_REPAY_NEW',
   PAY_AS_YOU_EARN: 'PAY_AS_YOU_EARN',
   REVISED_PAY_AS_YOU_EARN: 'REVISED_PAY_AS_YOU_EARN',
-  INCOME_CONTINGENT_REPAY: 'INCOME_CONTINGENT_REPAY'
+  INCOME_CONTINGENT_REPAY: 'INCOME_CONTINGENT_REPAY',
 }
 
 export const RepaymentEligible = {
   STANDARD_FIXED: () => true,
-  FIXED_EXTENDED: loan =>
+  FIXED_EXTENDED: (loan) =>
     loan.balance > 30000 &&
     [
       'DIRECT_SUBSIDIZED',
@@ -72,9 +72,9 @@ export const RepaymentEligible = {
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
       'FFEL_CONSOLIDATED',
       'FFEL_PRO',
-      'FFEL_PARENTS'
+      'FFEL_PARENTS',
     ].includes(loan.type),
-  GRADUATED: loan =>
+  GRADUATED: (loan) =>
     [
       'DIRECT_SUBSIDIZED',
       'DIRECT_UNSUBSIDIZED',
@@ -87,9 +87,9 @@ export const RepaymentEligible = {
       'STAFFORD_UNSUBSIDIZED',
       'FFEL_CONSOLIDATED',
       'FFEL_PRO',
-      'FFEL_PARENTS'
+      'FFEL_PARENTS',
     ].includes(loan.type),
-  GRADUATED_EXTENDED: loan =>
+  GRADUATED_EXTENDED: (loan) =>
     loan.balance > 30000 &&
     [
       'DIRECT_SUBSIDIZED',
@@ -103,7 +103,7 @@ export const RepaymentEligible = {
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
       'FFEL_CONSOLIDATED',
       'FFEL_PRO',
-      'FFEL_PARENTS'
+      'FFEL_PARENTS',
     ].includes(loan.type),
   INCOME_BASED_REPAY: (loan, income) =>
     partialFinancialHardship(loan, income, 0.15) &&
@@ -116,7 +116,7 @@ export const RepaymentEligible = {
       'FFEL_CONSOLIDATED',
       'DIRECT_PLUS_PRO',
       'DIRECT_CONSOLIDATED_SUBSIDIZED',
-      'DIRECT_CONSOLIDATED_UNSUBSIDIZED'
+      'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
     ].includes(loan.type),
   INCOME_BASED_REPAY_NEW: (loan, income) =>
     partialFinancialHardship(loan, income, 0.15) &&
@@ -125,7 +125,7 @@ export const RepaymentEligible = {
       'DIRECT_UNSUBSIDIZED',
       'DIRECT_CONSOLIDATED_SUBSIDIZED',
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
-      'DIRECT_PLUS_PRO'
+      'DIRECT_PLUS_PRO',
     ].includes(loan.type),
   PAY_AS_YOU_EARN: (loan, income) =>
     partialFinancialHardship(loan, income, 0.1) &&
@@ -134,24 +134,24 @@ export const RepaymentEligible = {
       'DIRECT_UNSUBSIDIZED',
       'DIRECT_CONSOLIDATED_SUBSIDIZED',
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
-      'DIRECT_PLUS_PRO'
+      'DIRECT_PLUS_PRO',
     ].includes(loan.type),
-  REVISED_PAY_AS_YOU_EARN: loan =>
+  REVISED_PAY_AS_YOU_EARN: (loan) =>
     [
       'DIRECT_SUBSIDIZED',
       'DIRECT_UNSUBSIDIZED',
       'DIRECT_CONSOLIDATED_SUBSIDIZED',
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
-      'DIRECT_PLUS_PRO'
+      'DIRECT_PLUS_PRO',
     ].includes(loan.type),
-  INCOME_CONTINGENT_REPAY: loan =>
+  INCOME_CONTINGENT_REPAY: (loan) =>
     [
       'DIRECT_SUBSIDIZED',
       'DIRECT_UNSUBSIDIZED',
       'DIRECT_CONSOLIDATED_SUBSIDIZED',
       'DIRECT_CONSOLIDATED_UNSUBSIDIZED',
-      'DIRECT_PLUS_PRO'
-    ].includes(loan.type)
+      'DIRECT_PLUS_PRO',
+    ].includes(loan.type),
 }
 
 export const RepaymentRequirements = {
@@ -159,43 +159,43 @@ export const RepaymentRequirements = {
   INCOME_BASED_REPAY_NEW: ['IDR', 'PFH'],
   INCOME_CONTINGENT_REPAY: ['IDR'],
   PAY_AS_YOU_EARN: ['IDR', 'PFH'],
-  REVISED_PAY_AS_YOU_EARN: ['IDR']
+  REVISED_PAY_AS_YOU_EARN: ['IDR'],
 }
 
 export const isPlanEligible = (type, loan, income) =>
   RepaymentEligible[type](loan, income)
 
 export const eligiblePlans = (loan, income) =>
-  Object.keys(Plans).filter(type => isPlanEligible(type, loan, income))
+  Object.keys(Plans).filter((type) => isPlanEligible(type, loan, income))
 
 export const RepaymentPlans = {
-  STANDARD_FIXED: loan => ({
+  STANDARD_FIXED: (loan) => ({
     label: 'Standard Fixed',
     eligible: isPlanEligible(Plans.STANDARD_FIXED, loan),
     description:
       'You pay a fixed amount each month of at least $50 for up to 10 years.',
-    ...fixedRateRepayment(loan, getLoanTerm(loan))
+    ...fixedRateRepayment(loan, getLoanTerm(loan)),
   }),
-  FIXED_EXTENDED: loan => ({
+  FIXED_EXTENDED: (loan) => ({
     label: 'Fixed Extended',
     eligible: isPlanEligible(Plans.FIXED_EXTENDED, loan),
     description:
       'You pay a fixed amount each month for up to 25 years. You must have a loan balance of over $30K in outstanding Direct Loans or over $30K in outstanding FFELP loans to qualify. You must have had no outstanding balance on a Direct Loan and/or a FFELP Loan as of October 7, 1998, or on the date you obtained a Direct Loan and/or a FFELP Loan after October 7, 1998.',
-    ...fixedRateRepayment(loan, 25)
+    ...fixedRateRepayment(loan, 25),
   }),
-  GRADUATED: loan => ({
+  GRADUATED: (loan) => ({
     label: 'Graduated',
     eligible: isPlanEligible(Plans.GRADUATED, loan),
     description:
       'You make monthly payments that increase every 2 years and last for up to 10 years. Each payment must cover at least the monthly interest on your loan. Any single payment cannot be more than 3 times greater than the amount of any other payment.',
-    ...graduatedRepayment(loan, getLoanTerm(loan))
+    ...graduatedRepayment(loan, getLoanTerm(loan)),
   }),
-  GRADUATED_EXTENDED: loan => ({
+  GRADUATED_EXTENDED: (loan) => ({
     label: 'Graduated Extended',
     eligible: isPlanEligible(Plans.GRADUATED_EXTENDED, loan),
     description:
       'You make monthly payments that increase every 2 years and last for up to 25 years. Each payment must cover at least the monthly interest on your loan. Any single payment cannot be more than 3 times greater than the amount any other payment. You must have a loan balance of over $30K to qualify.',
-    ...graduatedRepayment(loan, 25)
+    ...graduatedRepayment(loan, 25),
   }),
   INCOME_BASED_REPAY: (loan, income) => {
     const {payment, breakdown} = incomeBasedRepayment(loan, income)
@@ -212,7 +212,7 @@ export const RepaymentPlans = {
         'You make monthly payments that are no more than 15% of your discretionary income for up to 25 years. If your payment is less than the monthly accrued interest, the government may subsidize the unpaid interest on your subsidized loans for the first three years. Parent PLUS loans are not eligible for this plan.',
       forgiven,
       payment,
-      breakdown
+      breakdown,
     }
   },
   INCOME_BASED_REPAY_NEW: (loan, income) => {
@@ -230,7 +230,7 @@ export const RepaymentPlans = {
         'You make monthly payments that are no more than 10% of your discretionary income for up to 20 years. If your payment is less than the monthly accrued interest, the government may subsidize the unpaid interest on your subsidized loans for the first three years.  FFELP and parent PLUS loans are not eligible for this plan. To qualify for IBR for new borrowers, you must have had no outstanding balance on a Direct or FFELP loan when you borrowed a Direct loan on or after July 1, 2014.',
       forgiven,
       payment,
-      breakdown
+      breakdown,
     }
   },
   PAY_AS_YOU_EARN: (loan, income) => {
@@ -248,11 +248,23 @@ export const RepaymentPlans = {
         'You make monthly payments that are 10% of your discretionary income for up to 20 years. If your payment is less than the monthly accrued interest, the government may subsidize the unpaid interest on your subsidized loans for the first three years.  FFELP and parent PLUS loans are not eligible for this plan. FFELP loans, other than parent PLUS loans, can become eligible through loan consolidation. To qualify for PAYE, you need to have borrowed your first federal student loan after October 1, 2007, and you need to have received a disbursement of a Direct Loan or a Direct Consolidation Loan on or after October 1, 2011.',
       forgiven,
       payment,
-      breakdown
+      breakdown,
     }
   },
   REVISED_PAY_AS_YOU_EARN: (loan, income) => {
-    const {payment, breakdown} = payeBasedRepayment(loan, income, 25, 0.1, true)
+    // Override filing if not single to make sure incomes are combined
+    const reIncome = {...income}
+    if (reIncome.filing !== 'SINGLE') {
+      reIncome.filing = 'MARRIED_JOINT'
+    }
+
+    const {payment, breakdown} = payeBasedRepayment(
+      loan,
+      reIncome,
+      25,
+      0.1,
+      true
+    )
     const forgiven =
       breakdown.length === 25 * MONTHS
         ? breakdown[breakdown.length - 1].balance
@@ -260,13 +272,13 @@ export const RepaymentPlans = {
 
     return {
       label: 'Revised PAYE',
-      eligible: isPlanEligible(Plans.REVISED_PAY_AS_YOU_EARN, loan, income),
+      eligible: isPlanEligible(Plans.REVISED_PAY_AS_YOU_EARN, loan, reIncome),
       requirements: RepaymentRequirements[Plans.REVISED_PAY_AS_YOU_EARN],
       description:
         'You make monthly payments that are no more than 10% of your discretionary income for up to 20 or 25 years. If your payment is less than the monthly accrued interest, the government may subsidize the unpaid interest on your subsidized loans for the first three years.  They will subsidize half of the unpaid interest on all loans under this plan for as long as the monthly payment amount is less than the monthly accrued interest.  FFELP and parent PLUS loans are not eligible for this plan. FFELP loans, other than parent PLUS loans, can become eligible through loan consolidation.',
       forgiven,
       payment,
-      breakdown
+      breakdown,
     }
   },
   INCOME_CONTINGENT_REPAY: (loan, income) => {
@@ -284,9 +296,9 @@ export const RepaymentPlans = {
         'You make monthly payments that are either no more than 20% of your discretionary income or what you would pay under a standard 12-year plan based on your income, whichever is less for up to 25 years.  FFELP and parent PLUS loans are not eligible for this plan; however, these loans may become eligible for this plan if they are consolidated into a Direct Consolidation loan. This is the only income driven repayment plan available to parent PLUS loans that have been consolidated.',
       forgiven,
       payment,
-      breakdown
+      breakdown,
     }
-  }
+  },
 }
 
 export const getRepaymentOpions = (loan, income) =>
@@ -299,8 +311,8 @@ export const getRepaymentOpions = (loan, income) =>
     RepaymentPlans.INCOME_BASED_REPAY_NEW(loan, income),
     RepaymentPlans.PAY_AS_YOU_EARN(loan, income),
     RepaymentPlans.REVISED_PAY_AS_YOU_EARN(loan, income),
-    RepaymentPlans.INCOME_CONTINGENT_REPAY(loan, income)
-  ].filter(r => r.breakdown.length)
+    RepaymentPlans.INCOME_CONTINGENT_REPAY(loan, income),
+  ].filter((r) => r.breakdown.length)
 
 export const consolidateLoans = (loans, income) => {
   if (loans.length === 1) {
@@ -310,9 +322,9 @@ export const consolidateLoans = (loans, income) => {
   const balance = loans.reduce((b, l) => l.balance + b, 0)
   const rate = loans.reduce((r, l) => (l.balance / balance) * l.rate + r, 0)
   const payments = loans.reduce((p, l) => l.payments + p, 0)
-  const eligibility = loans.map(l => ({
+  const eligibility = loans.map((l) => ({
     type: l.type,
-    eligible: eligiblePlans(l, income)
+    eligible: eligiblePlans(l, income),
   }))
   // Choose loan type with least repayment options
   const [{type}] = eligibility.sort(
@@ -324,6 +336,6 @@ export const consolidateLoans = (loans, income) => {
     rate,
     payments,
     plan: '', // TODO(wes): Ask for guidance on what plan to choose
-    type
+    type,
   }
 }


### PR DESCRIPTION
- Allow entry of spouse income for non-single tax filing status
- Introduce getTotalIncome function which takes filing status into account
- Prettier